### PR TITLE
fix the deprecated warnings by Base.repeated on Julia 0.6

### DIFF
--- a/src/CatViews.jl
+++ b/src/CatViews.jl
@@ -4,6 +4,7 @@ module CatViews
 
 using Base.Cartesian
 import Base.ReshapedArray
+isdefined(Base, :Iterators) && (const repeated = Base.Iterators.repeated)
 import Iterators: chain, repeated
 
 export CatView, splitview, vecidx

--- a/src/splitview.jl
+++ b/src/splitview.jl
@@ -6,7 +6,7 @@
     quote
       len = 0
       @nexprs $N (n)->(s_n = len+1; e_n = len+prod(arr[n]); len = e_n) 
-      x = Array(T,len)
+      x = Array{T}(len)
       X = @ntuple $N (n)->(reshape(view(x,s_n:e_n),arr[n]))
       start = @ntuple $N (n)->(s_n)
       stop = @ntuple $N (n)->(e_n)


### PR DESCRIPTION
Hello, to hide the deprecated warning by Base.repeated on Julia 0.6,
and update for `Array{T}(m)`.
thanks.