### PR TITLE
Remove deprecation warning of typealias

### DIFF
--- a/src/splitview.jl
+++ b/src/splitview.jl
@@ -26,7 +26,7 @@ end
 end
 
 # unexported from Base
-typealias FastContiguousSubArray{T,N,P,I<:Tuple{Union{Colon, UnitRange}, Vararg{Any}}} SubArray{T,N,P,I,true}
+FastContiguousSubArray{T,N,P,I<:Tuple{Union{Colon, UnitRange}, Vararg{Any}}} = SubArray{T,N,P,I,true}
 
 parentindex(A::FastContiguousSubArray, i::Int) = A.offset1 + i
 parentindex(A::FastContiguousSubArray, i::Int...) = A.offset1 + prod(i)


### PR DESCRIPTION
Typealias is redundant in v0.6: JuliaLang/julia#20500