### PR TITLE
drop Julia v0.6 and support v0.7 and v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("CatViews"); Pkg.test("CatViews"; coverage=true)'

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Reshaping a view does not causing copying in Julia as of v0.5
 You can also get a list of the indices in `x` that represent the start and end of the arrays:
 
 ```julia
+using Random: randn!
 x,(A,B,C),s,e = splitview((3,3),(3,3),(3,3,3))
 for X in (A,B,C)
   randn!(X)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-IterTools
+julia 0.7

--- a/src/CatViews.jl
+++ b/src/CatViews.jl
@@ -4,7 +4,7 @@ module CatViews
 
 using Base.Cartesian
 import Base.ReshapedArray
-import IterTools: chain, repeated
+using Base.Iterators: repeated, flatten
 
 export CatView, splitview, vecidx
 

--- a/src/splitview.jl
+++ b/src/splitview.jl
@@ -1,12 +1,12 @@
 @inline splitview(a::Tuple...) = splitview(Float64,a)
-@inline splitview{T}(::Type{T},a::Tuple...) = splitview(T,a)
+@inline splitview(::Type{T},a::Tuple...) where {T} = splitview(T,a)
 @inline splitview(x::AbstractVector,a::Tuple...) = splitview(x,a)
 
-@generated function splitview{T,N}(::Type{T},arr::NTuple{N,Tuple})
+@generated function splitview(::Type{T},arr::NTuple{N,Tuple}) where {T,N}
     quote
       len = 0
       @nexprs $N (n)->(s_n = len+1; e_n = len+prod(arr[n]); len = e_n)
-      x = Array{T}(len)
+      x = Array{T}(undef, len)
       X = @ntuple $N (n)->(reshape(view(x,s_n:e_n),arr[n]))
       start = @ntuple $N (n)->(s_n)
       stop = @ntuple $N (n)->(e_n)
@@ -14,7 +14,7 @@
     end
 end
 
-@generated function splitview{T,N}(x::AbstractVector{T},arr::NTuple{N,Tuple})
+@generated function splitview(x::AbstractVector{T},arr::NTuple{N,Tuple}) where {T,N}
     quote
       len = 0
       @nexprs $N (n)->(s_n = len+1; e_n = len+prod(arr[n]); len = e_n)
@@ -30,16 +30,16 @@ const FastContiguousSubArray{T,N,P,I<:Tuple{Union{Colon, UnitRange}, Vararg{Any}
 
 parentindex(A::FastContiguousSubArray, i::Int) = A.offset1 + i
 parentindex(A::FastContiguousSubArray, i::Int...) = A.offset1 + prod(i)
-parentindex{N}(A::FastContiguousSubArray, i::NTuple{N,Int}) = A.offset1 + prod(i)
+parentindex(A::FastContiguousSubArray, i::NTuple{N,Int}) where {N} = A.offset1 + prod(i)
 
-@inline parentindex(A::ReshapedArray, i::Int...) = sub2ind(size(A), i...)
-parentindex{N}(A::ReshapedArray, i::NTuple{N,Int}) = sub2ind(size(A), i...)
+@inline parentindex(A::ReshapedArray, i::Int...) = LinearIndices(size(A))[i...]
+parentindex(A::ReshapedArray, i::NTuple{N,Int}) where {N} = LinearIndices(size(A))[i...]
 
 vecidx(A::Array, i::Int) = i
 
 vecidx(A::FastContiguousSubArray, i::Int) = vecidx(A.parent, parentindex(A, i))
 @inline vecidx(A::FastContiguousSubArray, i::Int...) = vecidx(A.parent, parentindex(A, i...))
-vecidx{N}(A::FastContiguousSubArray, i::NTuple{N,Int}) = vecidx(A.parent, parentindex(A, i))
+vecidx(A::FastContiguousSubArray, i::NTuple{N,Int}) where {N} = vecidx(A.parent, parentindex(A, i))
 
 @inline vecidx(A::ReshapedArray, i::Int...) = vecidx(A.parent, parentindex(A, i...))
-vecidx{N}(A::ReshapedArray, i::NTuple{N,Int}) = vecidx(A.parent, parentindex(A, i))
+vecidx(A::ReshapedArray, i::NTuple{N,Int}) where {N} = vecidx(A.parent, parentindex(A, i))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using CatViews
-using Base.Test
+using Test
+using Random: randn!
 
 @testset "CatView tests" begin
     x = CatView([1,2,3,4],[5,6,7,8])
@@ -134,7 +135,7 @@ end
 @testset "indexing" begin
 
     x,children, = splitview(Int64,(3,3),(2,2,2,2,2,2),(4,5,2),(10,),(1,10),(3,3))
-    copy!(x,1:length(x))
+    copyto!(x,1:length(x))
 
     for child in children
         for child_idx = eachindex(child)
@@ -146,7 +147,7 @@ end
     for child in children
         d = size(child)
         for i = 1:prod(d)
-            idx = ind2sub(d,i)
+            idx = Tuple(CartesianIndices(d)[i])
             pi1 = vecidx(child, idx)
             pi2 = vecidx(child, idx...)
             @test x[pi1] == x[pi2] == child[idx...] == child[i]


### PR DESCRIPTION
IterTools also deprecated it's `chain()` in favor of `Base.Iterators.flatten()` so I was able to remove the entire IterTools dependency as part of this PR. 