### PR TITLE
Add optimised mapreduce

### DIFF
--- a/src/catview.jl
+++ b/src/catview.jl
@@ -31,7 +31,7 @@ function Base.getindex(A::CatView, i::Int)
 
     a = 0
     b = A.len[1]
-    for j = 1:length(A.len)
+    @inbounds for j = 1:length(A.len)
         if i <= b
             return A.arr[j][i-a]
         else
@@ -46,7 +46,7 @@ function Base.setindex!(A::CatView, val, i::Int)
 
     a = 0
     b = A.len[1]
-    for j = 1:length(A.len)
+    @inbounds for j = 1:length(A.len)
         if i <= b
             A.arr[j][i-a] = val
             return val
@@ -57,11 +57,13 @@ function Base.setindex!(A::CatView, val, i::Int)
     end   
 end
 
+#Base.@propagate_inbounds 
 function Base.getindex(A::CatView, idx::Tuple{Integer,Integer})
     i,j = idx
     return A.arr[i][j]
 end
 
+#Base.@propagate_inbounds
 function Base.setindex!(A::CatView, val, idx::Tuple{Integer,Integer})
     i,j = idx
     return setindex!(A.arr[i], val, j)
@@ -73,4 +75,9 @@ end
     @nexprs $N (n)->(i_n = zip(repeated(n,length(A.arr[n])),eachindex(A.arr[n])))
     flatten( (@ntuple $N (n)->i_n) )
     end
+end
+
+
+function Base.mapreduce(f, op, A::CatView)
+	reduce(op, mapreduce(f, op, aa) for aa in A.arr)
 end

--- a/src/catview.jl
+++ b/src/catview.jl
@@ -1,7 +1,6 @@
 struct CatView{N,T<:Number} <: AbstractArray{T,1}
     arr::NTuple{N,SubArray{T}}
     len::NTuple{N,Integer}
-    inner::NTuple{N}  # iterators for each array
 end
 
 ## Constructors ##
@@ -10,7 +9,6 @@ end
 @generated function CatView(arr::NTuple{N,SubArray{T}}) where {N,T}
     quote
     len = @ntuple $N (n)->length(arr[n])
-    inner = @ntuple $N (n)->eachindex(arr[n])
     CatView{N,T}(arr,len,inner)
     end
 end
@@ -38,7 +36,7 @@ function Base.getindex(A::CatView, i::Int)
             a = b
             b = b + A.len[j+1]
         end
-    end   
+    end
 end
 
 function Base.setindex!(A::CatView, val, i::Int)

--- a/src/catview.jl
+++ b/src/catview.jl
@@ -9,7 +9,7 @@ end
 @generated function CatView(arr::NTuple{N,SubArray{T}}) where {N,T}
     quote
     len = @ntuple $N (n)->length(arr[n])
-    CatView{N,T}(arr,len,inner)
+    CatView{N,T}(arr,len)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,3 +155,12 @@ end
     end
 
 end
+
+
+@testset "mapreduce" begin
+    orig = collect(1:100)
+    xs = CatView(orig[21:80], orig[1:20], orig[81:end])
+
+    @test mapreduce(x->2x, +, xs) ==  sum(2*orig)
+    @test sum(xs) == sum(orig)
+end


### PR DESCRIPTION
In https://discourse.julialang.org/t/iterating-over-two-vectors-with-vcat-is-faster-than-iterators-flatten-and-catviews/15698/8

Some poor performance of CatViews was noted.
This fixes some of that,
and does some cleanup.


# Benchmark
```
julia> using BenchmarkTools;

julia> a = rand(1000); b=rand(1000);

julia> @btime sum($[a;b]) # baseline
  626.216 ns (0 allocations: 0 bytes)
992.4735874982961
```

## Before
```
julia> @btime sum($CatView(a,b))
  309.208 μs (7002 allocations: 110.03 KiB)
986.9114259144673
```


## after
```
julia> @btime sum($CatView(a,b))
  3.399 μs (13 allocations: 352 bytes)
986.911425914467
```

# Conclusion

So we've not yet matched the baseline performance,
but it is still a 2 orders of magnitude improvement.

